### PR TITLE
Switch to object instance reference of MergeFunc

### DIFF
--- a/mtbl.go
+++ b/mtbl.go
@@ -295,7 +295,7 @@ func MergerInit(mopt *MergerOptions) (m *Merger) {
 	defer C.mtbl_merger_options_destroy(&c_mopt)
 	if mopt.Merge != nil {
 		m.merge = mopt.Merge // keep gc reference
-		C.set_merger_callback_go(c_mopt, unsafe.Pointer(&mopt.Merge))
+		C.set_merger_callback_go(c_mopt, unsafe.Pointer(&m.merge))
 	} else if mopt.CMerge != nil {
 		C.set_merger_callback_c(c_mopt, mopt.CMerge, mopt.CMergeData)
 	}
@@ -372,7 +372,7 @@ func SorterInit(sopt *SorterOptions) (s *Sorter) {
 	}
 	if sopt.Merge != nil {
 		s.merge = sopt.Merge // keep gc reference
-		C.set_sorter_callback_go(c_sopt, unsafe.Pointer(&sopt.Merge))
+		C.set_sorter_callback_go(c_sopt, unsafe.Pointer(&s.merge))
 	} else if sopt.CMerge != nil {
 		C.set_sorter_callback_c(c_sopt, sopt.CMerge, sopt.CMergeData)
 	}


### PR DESCRIPTION
This fixes a crash when MergeFunc is used in the Sorter and FileSet Go callbacks. At the time the merge function is called, the reference has already been freed, leading to a crash like the following:
```
unexpected fault address 0x0
fatal error: fault
[signal 0xb code=0x80 addr=0x0 pc=0x47c6fa]

goroutine 1 [running, locked to thread]:
runtime.throw(0x5270e8, 0x5)
	/usr/lib/go-1.6/src/runtime/panic.go:547 +0x90 fp=0xc8202316c0 sp=0xc8202316a8
runtime.sigpanic()
	/usr/lib/go-1.6/src/runtime/sigpanic_unix.go:27 +0x2ab fp=0xc820231710 sp=0xc8202316c0
github.com/hdm/golang-mtbl.go_merge_callback(0xc820010468, 0x7fe0282735c8, 0xc, 0x7fe0282735d4, 0x13, 0x7fe028273604, 0x11, 0x7fe039ffad90, 0x7fe039ffad98)
	/work/go/src/github.com/hdm/golang-mtbl/cwrap.go:44 +0x35a fp=0xc8202318a0 sp=0xc820231710
github.com/hdm/golang-mtbl._cgoexpwrap_0a0376336b98_go_merge_callback(0xc820010468, 0x7fe0282735c8, 0xc, 0x7fe0282735d4, 0x13, 0x7fe028273604, 0x11, 0x7fe039ffad90, 0x7fe039ffad98)
	github.com/hdm/golang-mtbl/_obj/_cgo_gotypes.go:744 +0x7a fp=0xc8202318f0 sp=0xc8202318a0
runtime.call128(0x0, 0x7fe039ffabf8, 0x7fe039ffac90, 0x48)
	/usr/lib/go-1.6/src/runtime/asm_amd64.s:474 +0x51 fp=0xc820231978 sp=0xc8202318f0
runtime.cgocallbackg1()
	/usr/lib/go-1.6/src/runtime/cgocall.go:267 +0x10c fp=0xc8202319b0 sp=0xc820231978
runtime.cgocallbackg()
	/usr/lib/go-1.6/src/runtime/cgocall.go:180 +0xd7 fp=0xc820231a10 sp=0xc8202319b0
runtime.cgocallback_gofunc(0x406bf3, 0x4c7630, 0xc820231aa8)
	/usr/lib/go-1.6/src/runtime/asm_amd64.s:716 +0x60 fp=0xc820231a20 sp=0xc820231a10
runtime.asmcgocall(0x4c7630, 0xc820231aa8)
	/usr/lib/go-1.6/src/runtime/asm_amd64.s:567 +0x42 fp=0xc820231a28 sp=0xc820231a20
runtime.cgocall(0x4c7630, 0xc820231aa8, 0xc800000000)
	/usr/lib/go-1.6/src/runtime/cgocall.go:124 +0x133 fp=0xc820231a58 sp=0xc820231a28
github.com/hdm/golang-mtbl._Cfunc_mtbl_sorter_add(0xb4b090, 0xc8202196c0, 0xa, 0xc820222d00, 0x1d, 0x0)
	github.com/hdm/golang-mtbl/_obj/_cgo_gotypes.go:384 +0x41 fp=0xc820231aa8 sp=0xc820231a58
github.com/hdm/golang-mtbl.(*Sorter).Add(0xc82000e440, 0xc8202196c0, 0xa, 0x10, 0xc820222d00, 0x1d, 0x20, 0x0, 0x0)
	/work/go/src/github.com/hdm/golang-mtbl/mtbl.go:396 +0xe3 fp=0xc820231b60 sp=0xc820231aa8
main.main()
	/work/go/src/github.com/hdm/golang-mtbl/examples/csv2mtbl.go:141 +0x125b fp=0xc820231f50 sp=0xc820231b60
runtime.main()
	/usr/lib/go-1.6/src/runtime/proc.go:188 +0x2b0 fp=0xc820231fa0 sp=0xc820231f50
runtime.goexit()
	/usr/lib/go-1.6/src/runtime/asm_amd64.s:1998 +0x1 fp=0xc820231fa8 sp=0xc820231fa0

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/lib/go-1.6/src/runtime/asm_amd64.s:1998 +0x1
exit status 2
```

This patch changes the FileSet and Sorter callbacks to match the Merge callback, fixing the crash above.